### PR TITLE
feat:  文本编辑支持描边、优化文本拖动

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -230,13 +230,17 @@ export const DEFAULT_TEXT_ALIGN = "left";
 export const DEFAULT_VERTICAL_ALIGN = "top";
 export const DEFAULT_VERSION = "{version}";
 export const DEFAULT_TRANSFORM_HANDLE_SPACING = 2;
+export const TEXT_TRANSFORM_HANDLE_SPACING = 12;
 
 export const SIDE_RESIZING_THRESHOLD = 2 * DEFAULT_TRANSFORM_HANDLE_SPACING;
+export const TEXT_SIDE_RESIZING_THRESHOLD = 2 * TEXT_TRANSFORM_HANDLE_SPACING;
 // a small epsilon to make side resizing always take precedence
 // (avoids an increase in renders and changes to tests)
 export const EPSILON = 0.00001;
 export const DEFAULT_COLLISION_THRESHOLD =
   2 * SIDE_RESIZING_THRESHOLD - EPSILON;
+export const TEXT_COLLISION_THRESHOLD =
+  2 * TEXT_SIDE_RESIZING_THRESHOLD - EPSILON;
 
 export const COLOR_WHITE = "#ffffff";
 export const COLOR_CHARCOAL_BLACK = "#1e1e1e";

--- a/packages/element/src/bounds.ts
+++ b/packages/element/src/bounds.ts
@@ -2,9 +2,11 @@ import rough from "roughjs/bin/rough";
 
 import {
   arrayToMap,
+  DEFAULT_TRANSFORM_HANDLE_SPACING,
   invariant,
   rescalePoints,
   sizeOf,
+  TEXT_TRANSFORM_HANDLE_SPACING,
 } from "@excalidraw/common";
 
 import {
@@ -288,6 +290,7 @@ export const getElementAbsoluteCoords = (
       ];
     }
   }
+
   return [
     element.x,
     element.y,

--- a/packages/element/src/renderElement.ts
+++ b/packages/element/src/renderElement.ts
@@ -540,11 +540,12 @@ const drawElementOnCanvas = (
           const saveFillColor: string | CanvasGradient | CanvasPattern =
             context.fillStyle;
           context.fillStyle = element.textBackgroundColor;
+          const padding = 12;
           context.fillRect(
-            0,
-            -Math.ceil(element.height / 10 / 5),
-            element.width,
-            element.height,
+            0 - padding,
+            -Math.ceil(element.height / 10 / 5) - padding,
+            element.width + padding * 2,
+            element.height + padding * 2,
           );
           context.fillStyle = saveFillColor;
         }

--- a/packages/element/src/renderElement.ts
+++ b/packages/element/src/renderElement.ts
@@ -540,7 +540,7 @@ const drawElementOnCanvas = (
           const saveFillColor: string | CanvasGradient | CanvasPattern =
             context.fillStyle;
           context.fillStyle = element.textBackgroundColor;
-          const padding = 16;
+          const padding = 10;
           context.fillRect(
             0 - padding,
             0 - padding,

--- a/packages/element/src/renderElement.ts
+++ b/packages/element/src/renderElement.ts
@@ -540,10 +540,10 @@ const drawElementOnCanvas = (
           const saveFillColor: string | CanvasGradient | CanvasPattern =
             context.fillStyle;
           context.fillStyle = element.textBackgroundColor;
-          const padding = 12;
+          const padding = 16;
           context.fillRect(
             0 - padding,
-            -Math.ceil(element.height / 10 / 5) - padding,
+            0 - padding,
             element.width + padding * 2,
             element.height + padding * 2,
           );

--- a/packages/element/src/renderElement.ts
+++ b/packages/element/src/renderElement.ts
@@ -50,7 +50,7 @@ import {
   getBoundTextMaxHeight,
   getBoundTextMaxWidth,
 } from "./textElement";
-import { getLineHeightInPx } from "./textMeasurements";
+import { getFontStrokeWidth, getLineHeightInPx } from "./textMeasurements";
 import {
   isTextElement,
   isLinearElement,
@@ -558,8 +558,11 @@ const drawElementOnCanvas = (
               context.strokeStyle;
             const saveLineWidth = context.lineWidth;
             context.strokeStyle = element.textStrokeColor;
-            context.lineWidth =
-              (lineHeightPx * ((element.textStrokeWidth ?? 0) / 100)) / 3;
+            context.lineWidth = getFontStrokeWidth(
+              element.fontSize,
+              element.lineHeight,
+              element.textStrokeWidth,
+            );
             const saveLineJoin = context.lineJoin;
             context.lineJoin = "round";
             context.strokeText(

--- a/packages/element/src/resizeTest.ts
+++ b/packages/element/src/resizeTest.ts
@@ -5,7 +5,10 @@ import {
   type Radians,
 } from "@excalidraw/math";
 
-import { SIDE_RESIZING_THRESHOLD } from "@excalidraw/common";
+import {
+  SIDE_RESIZING_THRESHOLD,
+  TEXT_SIDE_RESIZING_THRESHOLD,
+} from "@excalidraw/common";
 
 import type { GlobalPoint, LineSegment, LocalPoint } from "@excalidraw/math";
 
@@ -18,7 +21,7 @@ import {
   getOmitSidesForDevice,
   canResizeFromSides,
 } from "./transformHandles";
-import { isImageElement, isLinearElement } from "./typeChecks";
+import { isImageElement, isLinearElement, isTextElement } from "./typeChecks";
 
 import type { Bounds } from "./bounds";
 import type {
@@ -96,9 +99,12 @@ export const resizeTest = <Point extends GlobalPoint | LocalPoint>(
     if (!(isLinearElement(element) && element.points.length <= 2)) {
       const SPACING = isImageElement(element)
         ? 0
+        : isTextElement(element)
+        ? TEXT_SIDE_RESIZING_THRESHOLD / zoom.value
         : SIDE_RESIZING_THRESHOLD / zoom.value;
-      const ZOOMED_SIDE_RESIZING_THRESHOLD =
-        SIDE_RESIZING_THRESHOLD / zoom.value;
+      const ZOOMED_SIDE_RESIZING_THRESHOLD = isTextElement(element)
+        ? SIDE_RESIZING_THRESHOLD / zoom.value
+        : SIDE_RESIZING_THRESHOLD / zoom.value;
       const sides = getSelectionBorders(
         pointFrom(x1 - SPACING, y1 - SPACING),
         pointFrom(x2 + SPACING, y2 + SPACING),

--- a/packages/element/src/textMeasurements.ts
+++ b/packages/element/src/textMeasurements.ts
@@ -95,6 +95,15 @@ export const getLineHeightInPx = (
   return fontSize * lineHeight;
 };
 
+export const getFontStrokeWidth = (
+  fontSize: ExcalidrawTextElement["fontSize"],
+  lineHeight: ExcalidrawTextElement["lineHeight"],
+  textStrokeWidth: ExcalidrawTextElement["textStrokeWidth"],
+) => {
+  const lineHeightPx = getLineHeightInPx(fontSize, lineHeight);
+  return (lineHeightPx * ((textStrokeWidth ?? 0) / 100)) / 3;
+};
+
 // FIXME rename to getApproxMinContainerHeight
 export const getApproxMinLineHeight = (
   fontSize: ExcalidrawTextElement["fontSize"],

--- a/packages/element/src/transformHandles.ts
+++ b/packages/element/src/transformHandles.ts
@@ -2,6 +2,7 @@ import {
   DEFAULT_TRANSFORM_HANDLE_SPACING,
   isAndroid,
   isIOS,
+  TEXT_TRANSFORM_HANDLE_SPACING,
 } from "@excalidraw/common";
 
 import { pointFrom, pointRotateRads } from "@excalidraw/math";
@@ -20,6 +21,7 @@ import {
   isFrameLikeElement,
   isImageElement,
   isLinearElement,
+  isTextElement,
 } from "./typeChecks";
 
 import type { Bounds } from "./bounds";
@@ -314,7 +316,9 @@ export const getTransformHandles = (
     ? DEFAULT_TRANSFORM_HANDLE_SPACING + 8
     : isImageElement(element)
     ? 0
-    : DEFAULT_TRANSFORM_HANDLE_SPACING;
+    : isTextElement(element)
+    ? TEXT_TRANSFORM_HANDLE_SPACING
+    : undefined;
   return getTransformHandlesFromCoords(
     getElementAbsoluteCoords(element, elementsMap, true),
     element.angle,
@@ -322,7 +326,11 @@ export const getTransformHandles = (
     pointerType,
     omitSides,
     margin,
-    isImageElement(element) ? 0 : undefined,
+    isImageElement(element)
+      ? 0
+      : isTextElement(element)
+      ? TEXT_TRANSFORM_HANDLE_SPACING
+      : undefined,
   );
 };
 

--- a/packages/excalidraw/renderer/interactiveScene.ts
+++ b/packages/excalidraw/renderer/interactiveScene.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_TRANSFORM_HANDLE_SPACING,
   FRAME_STYLE,
   invariant,
+  TEXT_TRANSFORM_HANDLE_SPACING,
   THEME,
   throttleRAF,
 } from "@excalidraw/common";
@@ -710,7 +711,7 @@ const renderTextBox = (
   selectionColor: InteractiveCanvasRenderConfig["selectionColor"],
 ) => {
   context.save();
-  const padding = (DEFAULT_TRANSFORM_HANDLE_SPACING * 2) / appState.zoom.value;
+  const padding = (TEXT_TRANSFORM_HANDLE_SPACING * 2) / appState.zoom.value;
   const width = text.width + padding * 2;
   const height = text.height + padding * 2;
   const cx = text.x + width / 2;
@@ -976,6 +977,8 @@ const _renderInteractiveScene = ({
               element.id === appState.croppingElementId ||
               isImageElement(element)
                 ? 0
+                : isTextElement(element)
+                ? TEXT_TRANSFORM_HANDLE_SPACING * 2
                 : undefined,
           });
         }

--- a/packages/excalidraw/wysiwyg/textWysiwyg.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.tsx
@@ -259,14 +259,17 @@ export const textWysiwyg = ({
       // Make sure text editor height doesn't go beyond viewport
       const editorMaxHeight =
         (appState.height - viewportY) / appState.zoom.value;
+
+      const padding = 16;
       Object.assign(editable.style, {
         font,
         // must be defined *after* font ¯\_(ツ)_/¯
         lineHeight: updatedTextElement.lineHeight,
         width: `${width}px`,
         height: `${height}px`,
-        left: `${viewportX}px`,
-        top: `${viewportY}px`,
+        left: `${viewportX - padding}px`,
+        top: `${viewportY - padding}px`,
+        padding: `${padding}px`,
         transform: getTransform(
           width,
           height,

--- a/packages/excalidraw/wysiwyg/textWysiwyg.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.tsx
@@ -11,6 +11,7 @@ import {
 } from "@excalidraw/common";
 
 import {
+  getFontStrokeWidth,
   originalContainerCache,
   updateOriginalContainerCache,
 } from "@excalidraw/element";
@@ -280,6 +281,14 @@ export const textWysiwyg = ({
         opacity: updatedTextElement.opacity / 100,
         filter: "var(--theme-filter)",
         maxHeight: `${editorMaxHeight}px`,
+        fontWeight: "bold",
+        "-webkit-text-stroke": `${getFontStrokeWidth(
+          updatedTextElement.fontSize,
+          updatedTextElement.lineHeight,
+          updatedTextElement.textStrokeWidth,
+        )}px ${updatedTextElement.textStrokeColor}`,
+        backgroundColor: updatedTextElement.textBackgroundColor,
+        "paint-order": "stroke fill",
       });
       editable.scrollTop = 0;
       // For some reason updating font attribute doesn't set font family

--- a/packages/excalidraw/wysiwyg/textWysiwyg.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.tsx
@@ -260,7 +260,7 @@ export const textWysiwyg = ({
       const editorMaxHeight =
         (appState.height - viewportY) / appState.zoom.value;
 
-      const padding = 16;
+      const padding = 10;
       Object.assign(editable.style, {
         font,
         // must be defined *after* font ¯\_(ツ)_/¯


### PR DESCRIPTION
1. 文本编辑支持描边、优化文本拖动