### PR TITLE
fix: 修复高亮、水印缺少描边颜色

### DIFF
--- a/packages/element/src/comparisons.ts
+++ b/packages/element/src/comparisons.ts
@@ -17,7 +17,9 @@ export const hasStrokeColor = (type: ElementOrToolType) =>
   type === "freedraw" ||
   type === "arrow" ||
   type === "line" ||
-  type === "text";
+  type === "text" ||
+  type === "watermark" ||
+  type === "highlight";
 
 export const hasTextStrokeColor = (type: ElementOrToolType) => type === "text";
 


### PR DESCRIPTION
1. 修复高亮、水印缺少描边颜色